### PR TITLE
Long Knock-back problem fix, Add Monster, FlyEntity implemented

### DIFF
--- a/src/milk/entitymanager/EntityManager.php
+++ b/src/milk/entitymanager/EntityManager.php
@@ -41,6 +41,21 @@ use pocketmine\plugin\PluginBase;
 use pocketmine\Server;
 use pocketmine\utils\TextFormat;
 use pocketmine\entity\Item as ItemEntity;
+use milk\entitymanager\entity\CaveSpider;
+use milk\entitymanager\entity\MagmaCube;
+use milk\entitymanager\entity\ZombieVillager;
+use pocketmine\block\Block;
+use milk\entitymanager\entity\Ghast;
+use milk\entitymanager\entity\Blaze;
+use milk\entitymanager\entity\Wolf;
+use milk\entitymanager\entity\Ocelot;
+use milk\entitymanager\entity\Mooshroom;
+use milk\entitymanager\entity\Rabbit;
+use milk\entitymanager\entity\IronGolem;
+use milk\entitymanager\entity\SnowGolem;
+use milk\entitymanager\entity\Slime;
+use milk\entitymanager\entity\Silverfish;
+use milk\entitymanager\entity\FireBall;
 
 class EntityManager extends PluginBase implements Listener{
 
@@ -60,6 +75,13 @@ class EntityManager extends PluginBase implements Listener{
             Pig::class,
             Sheep::class,
             Chicken::class,
+        	Slime::class,
+        	Wolf::class,
+        	Ocelot::class,
+        	Mooshroom::class,
+        	Rabbit::class,
+        	IronGolem::class,
+        	SnowGolem::class,
 
             Zombie::class,
             Creeper::class,
@@ -67,8 +89,16 @@ class EntityManager extends PluginBase implements Listener{
             Spider::class,
             PigZombie::class,
             Enderman::class,
+        	Silverfish::class,
+        	CaveSpider::class,
+        	MagmaCube::class,
+        	ZombieVillager::class,
+        	Ghast::class,
+        	Blaze::class,
         ];
         foreach($classes as $name) self::registerEntity($name);
+       
+        Entity::registerEntity(FireBall::class);
     }
 
     public function onEnable(){
@@ -94,12 +124,12 @@ class EntityManager extends PluginBase implements Listener{
         }
         self::$data = [
             "entity" => [
-                "maximum" => getData($data, "entity.maximum", 50),
+                "maximum" => getData($data, "entity.maximum", 30),
                 "explode" => getData($data, "entity.explode", true),
             ],
             "spawn" => [
-                "rand" => getData($data, "spawn.rand", "1/5"),
-                "tick" => getData($data, "spawn.tick", 150),
+                "rand" => getData($data, "spawn.rand", "1/3"),
+                "tick" => getData($data, "spawn.tick", 120),
             ],
             "autospawn" => [
                 "turn-on" => getData($data, "autospawn.turn-on", getData($data, "spawn.auto", true)),
@@ -307,6 +337,9 @@ class EntityManager extends PluginBase implements Listener{
         }elseif(isset(self::$spawn["{$pos->x}:{$pos->y}:{$pos->z}:{$pos->getLevel()->getFolderName()}"])){
             unset(self::$spawn["{$pos->x}:{$pos->y}:{$pos->z}:{$pos->getLevel()->getFolderName()}"]);
         }
+        if($ev->getBlock()->getId() == Block::STONE or $ev->getBlock()->getId() == Block::STONE_BRICK or $ev->getBlock()->getId() == Block::STONE_WALL or $ev->getBlock()->getId() == Block::STONE_BRICK_STAIRS)
+        	if($ev->getBlock()->getLightLevel() < 12 and mt_rand(1,3) < 2)
+        		self::createEntity("Silverfish", $pos);
     }
 
     public function ExplosionPrimeEvent(ExplosionPrimeEvent $ev){

--- a/src/milk/entitymanager/entity/BaseEntity.php
+++ b/src/milk/entitymanager/entity/BaseEntity.php
@@ -35,6 +35,15 @@ abstract class BaseEntity extends Creature{
     protected $attacker = null;
     protected $atkTime = 0;
 
+    protected $isFriendly = false;
+    
+    public function isFriendly(){
+    	return $this->isFriendly;
+    }
+    public function setFriendly($bool){
+    	$this->isFriendly = $bool;
+    }
+
     public function __destruct(){}
 
     public function onUpdate($currentTick){
@@ -45,7 +54,7 @@ abstract class BaseEntity extends Creature{
 
     public abstract function updateMove();
 
-    public abstract function targetOption(Player $player, $distance);
+    public abstract function targetOption(Creature $creature, $distance);
 
     public function getSaveId(){
         $class = new \ReflectionClass(static::class);
@@ -121,7 +130,7 @@ abstract class BaseEntity extends Creature{
     }
 
     public function attack($damage, EntityDamageEvent $source){
-        if($this->atkTime > 0) return;
+        //if($this->atkTime > 0) return;
         if($this->attackTime > 0 or $this->noDamageTicks > 0){
             $lastCause = $this->getLastDamageCause();
             if($lastCause !== null and $lastCause->getDamage() >= $damage) $source->setCancelled();
@@ -136,6 +145,8 @@ abstract class BaseEntity extends Creature{
             $this->stayTime = 0;
             $this->attacker = $source->getDamager();
             if($this instanceof PigZombie) $this->setAngry(1000);
+            if($this instanceof Wolf) $this->setAngry(1000);
+            if($this instanceof Ocelot) $this->setAngry(1000);
         }
 
         $pk = new EntityEventPacket();

--- a/src/milk/entitymanager/entity/Blaze.php
+++ b/src/milk/entitymanager/entity/Blaze.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace milk\entitymanager\entity;
+
+use pocketmine\entity\Entity;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\event\entity\EntityShootBowEvent;
+use pocketmine\event\entity\ProjectileLaunchEvent;
+use pocketmine\item\Item;
+use pocketmine\entity\ProjectileSource;
+use pocketmine\level\sound\LaunchSound;
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\DoubleTag;
+use pocketmine\nbt\tag\ListTag;
+use pocketmine\nbt\tag\FloatTag;
+
+class Blaze extends FlyMonster implements ProjectileSource{
+    const NETWORK_ID = 43;
+
+    public $width = 0.72;
+    public $height = 1.8;
+
+    protected $speed = 1.2;
+
+    public function initEntity(){
+        if(isset($this->namedtag->Health)){
+            $this->setHealth((int) $this->namedtag["Health"]);
+        }else{
+            $this->setHealth($this->getMaxHealth());
+        }
+        $this->setMinDamage([0, 4, 6, 9]);
+        $this->setMaxDamage([0, 4, 6, 9]);
+        parent::initEntity();
+        $this->created = true;
+    }
+
+    public function getName(){
+        return "Blaze";
+    }
+
+	public function attackEntity(Entity $player){
+        if($this->attackDelay > 20 && mt_rand(1, 32) < 4 && $this->distanceSquared($player) <= 100){
+            $this->attackDelay = 0;
+        
+            $f = 1.2;
+            $yaw = $this->yaw + mt_rand(-220, 220) / 10;
+            $pitch = $this->pitch + mt_rand(-120, 120) / 10;
+            $nbt = new CompoundTag("", [
+                "Pos" => new ListTag("Pos", [
+                    new DoubleTag("", $this->x + (-sin($yaw / 180 * M_PI) * cos($pitch / 180 * M_PI) * 0.5)),
+                    new DoubleTag("", $this->y + 1.62),
+                    new DoubleTag("", $this->z +(cos($yaw / 180 * M_PI) * cos($pitch / 180 * M_PI) * 0.5))
+                ]),
+                "Motion" => new ListTag("Motion", [
+                    new DoubleTag("", -sin($yaw / 180 * M_PI) * cos($pitch / 180 * M_PI) * $f),
+                    new DoubleTag("", -sin($pitch / 180 * M_PI) * $f),
+                    new DoubleTag("", cos($yaw / 180 * M_PI) * cos($pitch / 180 * M_PI) * $f)
+                ]),
+                "Rotation" => new ListTag("Rotation", [
+                    new FloatTag("", $yaw),
+                    new FloatTag("", $pitch)
+                ]),
+            ]);
+
+            /** @var Projectile $fireball */
+            $fireball = Entity::createEntity("FireBall", $this->chunk, $nbt, $this);
+            $fireball->setMotion ( $fireball->getMotion ()->multiply ( $f ) );
+            $ev = new EntityShootBowEvent($this, Item::get(Item::ARROW, 0, 1), $fireball, $f);
+
+            $this->server->getPluginManager()->callEvent($ev);
+
+            $projectile = $ev->getProjectile();
+            if($ev->isCancelled()){
+                $projectile->kill();
+            }elseif($projectile instanceof Projectile){
+                $this->server->getPluginManager()->callEvent($launch = new ProjectileLaunchEvent($projectile));
+                if($launch->isCancelled()){
+                    $projectile->kill();
+                }else{
+                    $projectile->spawnToAll();
+                    $this->level->addSound(new LaunchSound($this), $this->getViewers());
+                }
+            }
+        }
+    }
+
+    public function getDrops(){
+        $drops = [];
+        if($this->lastDamageCause instanceof EntityDamageByEntityEvent){
+        	$drops[] = Item::get(Item::GLOWSTONE_DUST, 0, mt_rand(0, 2));
+        }
+        return $drops;
+    }
+
+}

--- a/src/milk/entitymanager/entity/CaveSpider.php
+++ b/src/milk/entitymanager/entity/CaveSpider.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace milk\entitymanager\entity;
+
+use pocketmine\entity\Entity;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\event\entity\EntityDamageEvent;
+use pocketmine\item\Item;
+
+class CaveSpider extends Monster{
+    const NETWORK_ID = 40;
+
+    public $width = 1.5;
+    public $height = 1.2;
+
+    protected $speed = 1.3;
+
+    public function initEntity(){
+        $this->setMaxHealth(12);
+        if(isset($this->namedtag->Health)){
+            $this->setHealth((int) $this->namedtag["Health"]);
+        }else{
+            $this->setHealth($this->getMaxHealth());
+        }
+        $this->setMinDamage([2, 3]);
+        $this->setMaxDamage([2, 3]);
+        parent::initEntity();
+        $this->created = true;
+    }
+
+    public function getName(){
+        return "CaveSpider";
+    }
+
+    public function attackEntity(Entity $player){
+        if($this->attackDelay > 10 && $this->distanceSquared($player) < 1.32){
+            $this->attackDelay = 0;
+            $ev = new EntityDamageByEntityEvent($this, $player, EntityDamageEvent::CAUSE_ENTITY_ATTACK, $this->getDamage());
+            $player->attack($ev->getFinalDamage(), $ev);
+        }
+    }
+
+    public function getDrops(){
+        return $this->lastDamageCause instanceof EntityDamageByEntityEvent ? [Item::get(Item::STRING, 0, mt_rand(0, 2))] : [];
+    }
+
+}

--- a/src/milk/entitymanager/entity/Chicken.php
+++ b/src/milk/entitymanager/entity/Chicken.php
@@ -5,6 +5,7 @@ namespace milk\entitymanager\entity;
 use pocketmine\item\Item;
 use pocketmine\Player;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\entity\Creature;
 
 class Chicken extends Animal{
     const NETWORK_ID = 10;
@@ -27,8 +28,10 @@ class Chicken extends Animal{
         $this->created = true;
     }
 
-    public function targetOption(Player $player, $distance){
-        return $player->spawned && $player->isAlive() && !$player->closed && $player->getInventory()->getItemInHand()->getId() == Item::SEEDS && $distance <= 49;
+    public function targetOption(Creature $creature, $distance){
+    	if($creature instanceof Player)
+        	return $creature->isAlive() && !$creature->closed && $creature->getInventory()->getItemInHand()->getId() == Item::SEEDS && $distance <= 49;
+    	return false;
     }
 
     public function getDrops(){

--- a/src/milk/entitymanager/entity/Cow.php
+++ b/src/milk/entitymanager/entity/Cow.php
@@ -5,6 +5,7 @@ namespace milk\entitymanager\entity;
 use pocketmine\item\Item;
 use pocketmine\Player;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\entity\Creature;
 
 class Cow extends Animal{
     const NETWORK_ID = 11;
@@ -27,8 +28,10 @@ class Cow extends Animal{
         $this->created = true;
     }
 
-    public function targetOption(Player $player, $distance){
-        return $player->spawned && $player->isAlive() && !$player->closed && $player->getInventory()->getItemInHand()->getId() == Item::WHEAT && $distance <= 49;
+    public function targetOption(Creature $creature, $distance){
+    	if($creature instanceof Player)
+        	return $creature->isAlive() && !$creature->closed && $creature->getInventory()->getItemInHand()->getId() == Item::WHEAT && $distance <= 49;
+    	return false;
     }
 
     public function getDrops(){

--- a/src/milk/entitymanager/entity/FireBall.php
+++ b/src/milk/entitymanager/entity/FireBall.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____  
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \ 
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/ 
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_| 
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ * 
+ *
+*/
+
+namespace milk\entitymanager\entity;
+
+use pocketmine\level\format\FullChunk;
+use pocketmine\level\particle\CriticalParticle;
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\network\protocol\AddEntityPacket;
+use pocketmine\Player;
+use pocketmine\entity\Projectile;
+use pocketmine\entity\Entity;
+use pocketmine\level\Explosion;
+use pocketmine\event\entity\ExplosionPrimeEvent;
+
+class FireBall extends Projectile{
+	const NETWORK_ID = 85;
+
+	public $width = 0.5;
+	public $length = 0.5;
+	public $height = 0.5;
+
+	protected $gravity = 0.05;
+	protected $drag = 0.01;
+
+	protected $damage = 4;
+
+	protected $isCritical;
+	protected $canExplode = false;
+
+	public function __construct(FullChunk $chunk, CompoundTag $nbt, Entity $shootingEntity = null, $critical = false){
+		$this->isCritical = (bool) $critical;
+		parent::__construct($chunk, $nbt, $shootingEntity);
+	}
+	public function isExplode(){
+		return $this->canExplode;
+	}
+	public function setExplode($bool){
+		$this->canExplode = $bool;
+	}
+	public function onUpdate($currentTick){
+		if($this->closed){
+			return false;
+		}
+
+		$this->timings->startTiming();
+
+		$hasUpdate = parent::onUpdate($currentTick);
+
+		if(!$this->hadCollision and $this->isCritical){
+			$this->level->addParticle(new CriticalParticle($this->add(
+				$this->width / 2 + mt_rand(-100, 100) / 500,
+				$this->height / 2 + mt_rand(-100, 100) / 500,
+				$this->width / 2 + mt_rand(-100, 100) / 500)));
+		}elseif($this->onGround){
+			$this->isCritical = false;
+		}
+
+		if($this->age > 1200 or $this->isCollided){
+			if($this->isCollided and $this->canExplode){
+				$this->server->getPluginManager()->callEvent($ev = new ExplosionPrimeEvent($this, 2.8));
+				if(!$ev->isCancelled()){
+					$explosion = new Explosion ( $this, $ev->getForce (), $this->shootingEntity );
+					//if($ev->isBlockBreaking())
+					//	$explosion->explodeA();
+					$explosion->explodeB();
+				}
+			}
+			$this->kill();
+			$hasUpdate = true;
+		}
+
+		$this->timings->stopTiming();
+
+		return $hasUpdate;
+	}
+
+	public function spawnTo(Player $player){
+		$pk = new AddEntityPacket();
+		$pk->type = FireBall::NETWORK_ID;
+		$pk->eid = $this->getId();
+		$pk->x = $this->x;
+		$pk->y = $this->y;
+		$pk->z = $this->z;
+		$pk->speedX = $this->motionX;
+		$pk->speedY = $this->motionY;
+		$pk->speedZ = $this->motionZ;
+		$pk->metadata = $this->dataProperties;
+		$player->dataPacket($pk);
+
+		parent::spawnTo($player);
+	}
+}

--- a/src/milk/entitymanager/entity/FlyEntity.php
+++ b/src/milk/entitymanager/entity/FlyEntity.php
@@ -4,41 +4,72 @@ namespace milk\entitymanager\entity;
 
 use pocketmine\math\Vector3;
 use pocketmine\Player;
+use pocketmine\entity\Creature;
 
 abstract class FlyEntity extends BaseEntity{
-    //TODO: This isn't implemented yet
-
     private function checkTarget(){
-        /*$get = function(Vector3 $pos, Vector3 $pos1){
+        $get = function(Vector3 $pos, Vector3 $pos1){
             return ($pos1->x - $pos->x) ** 2 + ($pos1->y - $pos->y) ** 2 + ($pos1->z - $pos->z) ** 2;
         };
+    	if(count($this->getViewers()) == 0)
+    		return;
         $target = $this->baseTarget;
-        if(!$target instanceof Player or !$this->targetOption($target, $get($this, $target))){
+        if(!$target instanceof Creature or !$this->targetOption($target, $get($this, $target))){
             $near = PHP_INT_MAX;
-            foreach($this->getViewers() as $player){
-                if(($distance = $this->distanceSquared($player)) > $near or !$this->targetOption($player, $distance)) continue;
+            
+        	foreach ($this->getLevel()->getEntities() as $creature){
+            	if(! $creature instanceof Creature) continue;
+            	if($creature instanceof Animal) continue;
+            	
+            	if($creature === $this) continue;
+            	if($creature instanceof BaseEntity)
+            		if($creature->isFriendly() == $this->isFriendly()) continue;
+            	
+                if(($distance = $this->distanceSquared($creature)) > $near or !$this->targetOption($creature, $distance)) continue;
                 $near = $distance;
-                $this->baseTarget = $player;
+                $this->baseTarget = $creature;
             }
         }
-        if($this->baseTarget instanceof Player) return;*/
+        if($this->baseTarget instanceof Creature)
+        	if($this->baseTarget->isAlive())
+        		return;
 
         if($this->stayTime > 0){
             if(mt_rand(1, 125) > 4) return;
             $x = mt_rand(25, 80);
             $z = mt_rand(25, 80);
-            $this->baseTarget = $this->add(mt_rand(0, 1) ? $x : -$x, mt_rand(-20, 20) / 10, mt_rand(0, 1) ? $z : -$z);
+            $ground = $this->getLevel()->getHighestBlockAt($this->x, $this->z);
+            $maxAltitude = $ground + 10;
+            if($this->y > $maxAltitude){
+            	$y = mt_rand(-10, -7);
+            }else{
+            	$y = mt_rand(-2, 2);
+            }
+            $this->baseTarget = $this->add(mt_rand(0, 1) ? $x : -$x, $y, mt_rand(0, 1) ? $z : -$z);
         }elseif(mt_rand(1, 420) == 1){
             $this->stayTime = mt_rand(95, 420);
             $x = mt_rand(25, 80);
             $z = mt_rand(25, 80);
-            $this->baseTarget = $this->add(mt_rand(0, 1) ? $x : -$x, mt_rand(-20, 20) / 10, mt_rand(0, 1) ? $z : -$z);
+            $ground = $this->getLevel()->getHighestBlockAt($this->x, $this->z);
+            $maxAltitude = $ground + 10;
+            if($this->y > $maxAltitude){
+            	$y = mt_rand(-10, -7);
+            }else{
+            	$y = mt_rand(-2, 2);
+            }
+            $this->baseTarget = $this->add(mt_rand(0, 1) ? $x : -$x, $y, mt_rand(0, 1) ? $z : -$z);
         }elseif($this->moveTime <= 0 or !$this->baseTarget instanceof Vector3){
             $this->moveTime = mt_rand(100, 1000);
             $x = mt_rand(25, 80);
-            $y = mt_rand(10, 40);
             $z = mt_rand(25, 80);
-            $this->baseTarget = $this->add(mt_rand(0, 1) ? $x : -$x, mt_rand(0, 1) ? $y : -$y, mt_rand(0, 1) ? $z : -$z);
+            $ground = $this->getLevel()->getHighestBlockAt($this->x, $this->z);
+            $maxAltitude = $ground + 10;
+            if($this->y > $maxAltitude){
+            	$y = mt_rand(-10, -7);
+            }else{
+            	$y = mt_rand(-2, 2);
+            }
+            $this->baseTarget = $this->add(mt_rand(0, 1) ? $x : -$x, $y, mt_rand(0, 1) ? $z : -$z);
         }
     }
 
@@ -57,9 +88,15 @@ abstract class FlyEntity extends BaseEntity{
                 $this->motionZ = -0.5 * ($diff == 0 ? 0 : $z / $diff);
             }
             $this->move($this->motionX, $this->motionY, $this->motionZ);
-            if(--$this->atkTime <= 0) $this->attacker = null;
+            if(--$this->atkTime <= 0){
+            	$this->attacker = null;
+            	$this->motionX = 0;
+            	$this->motionY = 0;
+            	$this->motionZ = 0;
+            }
             return null;
         }
+        
         $before = $this->baseTarget;
         $this->checkTarget();
         if($this->baseTarget instanceof Player or $before !== $this->baseTarget){
@@ -72,12 +109,13 @@ abstract class FlyEntity extends BaseEntity{
             }else{
                 $diff = abs($x) + abs($z);
                 $this->motionX = $this->speed * 0.15 * ($x / $diff);
-                $this->motionY = $this->speed * 0.04 * ($y / abs($x) + abs($y));
+                $this->motionY = $this->speed * 0.15 * ($y / $diff);
                 $this->motionZ = $this->speed * 0.15 * ($z / $diff);
             }
             $f = sqrt(($this->motionX ** 2) + ($this->motionZ ** 2));
             $this->yaw = (-atan2($this->motionX, $this->motionZ) * 180 / M_PI);
-            $this->pitch = (-atan2($f, $this->motionY) * 180 / M_PI);
+            //$this->pitch = (-atan2($f, $this->motionY) * 180 / M_PI);
+            $this->pitch = $y == 0 ? 0 : rad2deg(-atan2($y, sqrt($x ** 2 + $z ** 2)));
         }
         $target = $this->mainTarget != null ? $this->mainTarget : $this->baseTarget;
         if($this->stayTime > 0){

--- a/src/milk/entitymanager/entity/FlyMonster.php
+++ b/src/milk/entitymanager/entity/FlyMonster.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace milk\entitymanager\entity;
+
+use pocketmine\block\Water;
+use pocketmine\entity\Effect;
+use pocketmine\entity\Entity;
+use pocketmine\event\entity\EntityDamageEvent;
+use pocketmine\event\Timings;
+use pocketmine\math\Math;
+use pocketmine\math\Vector3;
+use pocketmine\Player;
+use pocketmine\Server;
+use pocketmine\entity\Creature;
+
+abstract class FlyMonster extends FlyEntity{
+
+    private $minDamage = [0, 0, 0, 0];
+    private $maxDamage = [0, 0, 0, 0];
+
+    private $entityTick = 0;
+
+    protected $attackDelay = 0;
+
+    public abstract function attackEntity(Entity $player);
+
+    public function getDamage($difficulty = null) : float{
+        return mt_rand($this->getMinDamage($difficulty), $this->getMaxDamage($difficulty));
+    }
+
+    public function getMinDamage($difficulty = null) : float{
+        if($difficulty === null or !is_numeric($difficulty) || $difficulty > 3 || $difficulty < 0){
+            $difficulty = Server::getInstance()->getDifficulty();
+        }
+        $difficulty = (int) $difficulty;
+        return $this->minDamage[$difficulty];
+    }
+
+    public function getMaxDamage($difficulty = null) : float{
+        if($difficulty === null or !is_numeric($difficulty) || $difficulty > 3 || $difficulty < 0){
+            $difficulty = Server::getInstance()->getDifficulty();
+        }
+        $difficulty = (int) $difficulty;
+        return $this->maxDamage[$difficulty];
+    }
+
+    /**
+     * @param float|float[] $damage
+     * @param int $difficulty
+     */
+    public function setDamage($damage, $difficulty = null){
+        $this->setMinDamage($damage, $difficulty);
+        $this->setMaxDamage($damage, $difficulty);
+    }
+
+    public function setMinDamage($damage, $difficulty = null){
+        $difficulty = $difficulty === null ? Server::getInstance()->getDifficulty() : (int) $difficulty;
+        if(is_array($damage)){
+            foreach($damage as $key => $float){
+                if(!is_numeric($key) || !is_numeric($float) || $key > 3 || $key < 0) continue;
+                $key = (int) $key;
+                $float = (float) $float;
+                if($this->maxDamage[$key] >= $float) $this->minDamage[$key] = $float;
+            }
+        }elseif($difficulty >= 1 && $difficulty <= 3){
+            $damage = (float) $damage;
+            if($this->maxDamage[$difficulty] >= $damage) $this->minDamage[$difficulty] = $damage;
+        }
+    }
+
+    public function setMaxDamage($damage, $difficulty = null){
+        $difficulty = $difficulty === null ? Server::getInstance()->getDifficulty() : (int) $difficulty;
+        if(is_array($damage)){
+            foreach($damage as $key => $float){
+                if(!is_numeric($key) || !is_numeric($float) || $key > 3 || $key < 0) continue;
+                $key = (int) $key;
+                $float = (float) $float;
+                if($this->minDamage[$key] <= $float) $this->maxDamage[$key] = $float;
+            }
+        }elseif($difficulty >= 1 && $difficulty <= 3){
+            $damage = (float) $damage;
+            if($this->minDamage[$difficulty] <= $damage) $this->maxDamage[$difficulty] = $damage;
+        }
+    }
+
+    public function updateTick(){
+        if($this->server->getDifficulty() < 1){
+            $this->close();
+            return;
+        }
+        if(!$this->isAlive()){
+            if(++$this->deadTicks >= 23) $this->close();
+            return;
+        }
+
+        --$this->moveTime;
+        ++$this->attackDelay;
+        $target = $this->updateMove();
+        if($target instanceof Entity){
+            $this->attackEntity($target);
+        }elseif($target instanceof Vector3){
+            if((($this->x - $target->x) ** 2 + ($this->z - $target->z) ** 2) <= 1) $this->moveTime = 0;
+        }
+        if($this->entityTick++ >= 5){
+            $this->entityTick = 0;
+            $this->entityBaseTick(5);
+        }
+    }
+
+    public function entityBaseTick($tickDiff = 1){
+        Timings::$timerEntityBaseTick->startTiming();
+
+        if(!$this->isCreated()){
+            return false;
+        }
+
+        $hasUpdate = Entity::entityBaseTick($tickDiff);
+        if($this->atkTime > 0){
+            $this->atkTime -= $tickDiff;
+        }
+        if($this->isInsideOfSolid()){
+            $hasUpdate = true;
+            $ev = new EntityDamageEvent($this, EntityDamageEvent::CAUSE_SUFFOCATION, 1);
+            $this->attack($ev->getFinalDamage(), $ev);
+        }
+        if($this instanceof Enderman){
+            if($this->level->getBlock(new Vector3(Math::floorFloat($this->x), (int) $this->y, Math::floorFloat($this->z))) instanceof Water){
+                $ev = new EntityDamageEvent($this, EntityDamageEvent::CAUSE_DROWNING, 2);
+                $this->attack($ev->getFinalDamage(), $ev);
+                $this->move(mt_rand(-20, 20), mt_rand(-20, 20), mt_rand(-20, 20));
+            }
+        }else{
+            if(!$this->hasEffect(Effect::WATER_BREATHING) && $this->isInsideOfWater()){
+                $hasUpdate = true;
+                $airTicks = $this->getDataProperty(self::DATA_AIR) - $tickDiff;
+                if($airTicks <= -20){
+                    $airTicks = 0;
+                    $ev = new EntityDamageEvent($this, EntityDamageEvent::CAUSE_DROWNING, 2);
+                    $this->attack($ev->getFinalDamage(), $ev);
+                }
+                $this->setDataProperty(self::DATA_AIR, self::DATA_TYPE_SHORT, $airTicks);
+            }else{
+                $this->setDataProperty(self::DATA_AIR, self::DATA_TYPE_SHORT, 300);
+            }
+        }
+
+        Timings::$timerEntityBaseTick->stopTiming();
+        return $hasUpdate;
+    }
+
+    public function targetOption(Creature $creature, $distance){
+        if($creature instanceof Player)
+        	return $creature->spawned && $creature->isAlive() && !$creature->closed && $creature->isSurvival() && $distance <= 200;
+        return $creature->isAlive() && !$creature->closed && $distance <= 200;
+    }
+
+}

--- a/src/milk/entitymanager/entity/Ghast.php
+++ b/src/milk/entitymanager/entity/Ghast.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace milk\entitymanager\entity;
+
+use pocketmine\entity\Entity;
+use pocketmine\event\entity\EntityShootBowEvent;
+use pocketmine\event\entity\ProjectileLaunchEvent;
+use pocketmine\item\Item;
+use pocketmine\entity\ProjectileSource;
+use pocketmine\level\sound\LaunchSound;
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\DoubleTag;
+use pocketmine\nbt\tag\ListTag;
+use pocketmine\nbt\tag\FloatTag;
+use pocketmine\entity\Projectile;
+
+class Ghast extends FlyMonster implements ProjectileSource{
+    const NETWORK_ID = 41;
+
+    public $width = 4;
+    public $height = 4;
+
+    protected $speed = 1.2;
+
+    public function initEntity(){
+        if(isset($this->namedtag->Health)){
+            $this->setHealth((int) $this->namedtag["Health"]);
+        }else{
+            $this->setHealth($this->getMaxHealth());
+        }
+        $this->setMinDamage([0, 4, 6, 9]);
+        $this->setMaxDamage([0, 4, 6, 9]);
+        parent::initEntity();
+        $this->created = true;
+    }
+
+    public function getName(){
+        return "Ghast";
+    }
+
+	public function attackEntity(Entity $player){
+        if($this->attackDelay > 30 && mt_rand(1, 32) < 4 && $this->distanceSquared($player) <= 200){
+            $this->attackDelay = 0;
+        
+            $f = 2;
+            $yaw = $this->yaw + mt_rand(-220, 220) / 10;
+            $pitch = $this->pitch + mt_rand(-120, 120) / 10;
+            $nbt = new CompoundTag("", [
+                "Pos" => new ListTag("Pos", [
+                    new DoubleTag("", $this->x + (-sin($yaw / 180 * M_PI) * cos($pitch / 180 * M_PI) * 2)),
+                    new DoubleTag("", $this->y + 2),
+                    new DoubleTag("", $this->z +(cos($yaw / 180 * M_PI) * cos($pitch / 180 * M_PI) * 2))
+                ]),
+                "Motion" => new ListTag("Motion", [
+                    new DoubleTag("", -sin($yaw / 180 * M_PI) * cos($pitch / 180 * M_PI)),
+                    new DoubleTag("", -sin($pitch / 180 * M_PI) * $f),
+                    new DoubleTag("", cos($yaw / 180 * M_PI) * cos($pitch / 180 * M_PI))
+                ]),
+                "Rotation" => new ListTag("Rotation", [
+                    new FloatTag("", $yaw),
+                    new FloatTag("", $pitch)
+                ]),
+            ]);
+
+            /** @var Projectile $fireball */
+            $fireball = Entity::createEntity("FireBall", $this->chunk, $nbt, $this);
+            if($fireball instanceof FireBall)
+            	$fireball->setExplode(true);
+            $fireball->setMotion ( $fireball->getMotion ()->multiply ( $f ) );
+            $ev = new EntityShootBowEvent($this, Item::get(Item::ARROW, 0, 1), $fireball, $f);
+
+            $this->server->getPluginManager()->callEvent($ev);
+            $projectile = $ev->getProjectile();
+            if($ev->isCancelled()){
+                $projectile->kill();
+            }elseif($projectile instanceof Projectile){
+                $this->server->getPluginManager()->callEvent($launch = new ProjectileLaunchEvent($projectile));
+                if($launch->isCancelled()){
+                    $projectile->kill();
+                }else{
+                    $projectile->spawnToAll();
+                    $this->level->addSound(new LaunchSound($this), $this->getViewers());
+                }
+            }
+        }
+    }
+
+    public function getDrops(){
+        return [];
+    }
+
+}

--- a/src/milk/entitymanager/entity/IronGolem.php
+++ b/src/milk/entitymanager/entity/IronGolem.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace milk\entitymanager\entity;
+
+use pocketmine\entity\Entity;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\event\entity\EntityDamageEvent;
+use pocketmine\item\Item;
+use pocketmine\math\Vector3;
+use pocketmine\entity\Creature;
+use pocketmine\Player;
+
+class IronGolem extends Monster{
+    const NETWORK_ID = 20;
+
+    public $width = 1.3;
+    public $height = 1.8;
+
+    protected $speed = 1.1;
+
+    public function initEntity(){
+    	$this->setMaxHealth(100);
+        if(isset($this->namedtag->Health)){
+            $this->setHealth((int) $this->namedtag["Health"]);
+        }else{
+            $this->setHealth($this->getMaxHealth());
+        }
+        $this->setFriendly(true);
+        $this->setMinDamage([0, 3, 4, 6]);
+        $this->setMaxDamage([0, 3, 4, 6]);
+        parent::initEntity();
+        $this->created = true;
+    }
+
+    public function getName(){
+        return "IronGolem";
+    }
+
+    public function attackEntity(Entity $player){
+        if($this->attackDelay > 10 && $this->distanceSquared($player) < 4){
+            $this->attackDelay = 0;
+            $ev = new EntityDamageByEntityEvent($this, $player, EntityDamageEvent::CAUSE_ENTITY_ATTACK, $this->getDamage());
+            $player->attack($ev->getFinalDamage(), $ev);
+            $player->setMotion(new Vector3(0, 0.7, 0));
+        }
+    }
+
+    public function getDrops(){
+        $drops = [];
+        if($this->lastDamageCause instanceof EntityDamageByEntityEvent){
+            switch(mt_rand(0, 2)){
+                case 0:
+                    $drops[] = Item::get(Item::FEATHER, 0, 1);
+                    break;
+                case 1:
+                    $drops[] = Item::get(Item::CARROT, 0, 1);
+                    break;
+                case 2:
+                    $drops[] = Item::get(Item::POTATO, 0, 1);
+                    break;
+            }
+        }
+        return $drops;
+    }
+    public function targetOption(Creature $creature, $distance){
+    	if(! $creature instanceof Player)
+    		return $creature->isAlive() && $distance <= 60;
+    	return false;
+    }
+}

--- a/src/milk/entitymanager/entity/MagmaCube.php
+++ b/src/milk/entitymanager/entity/MagmaCube.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace milk\entitymanager\entity;
+
+use pocketmine\entity\Entity;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\event\entity\EntityDamageEvent;
+
+class MagmaCube extends Monster{
+    const NETWORK_ID = 42;
+
+    public $width = 1.2;
+    public $height = 1.2;
+
+    protected $speed = 0.8;
+
+    public function initEntity(){
+        if(isset($this->namedtag->Health)){
+            $this->setHealth((int) $this->namedtag["Health"]);
+        }else{
+            $this->setHealth(16);
+        }
+        $this->setMinDamage([0, 3, 4, 6]);
+        $this->setMaxDamage([0, 3, 4, 6]);
+        parent::initEntity();
+        $this->created = true;
+    }
+
+    public function getName(){
+        return "MagmaCube";
+    }
+
+    public function attackEntity(Entity $player){
+        if($this->attackDelay > 10 && $this->distanceSquared($player) < 1){
+            $this->attackDelay = 0;
+            $ev = new EntityDamageByEntityEvent($this, $player, EntityDamageEvent::CAUSE_ENTITY_ATTACK, $this->getDamage());
+            $player->attack($ev->getFinalDamage(), $ev);
+        }
+    }
+
+    public function getDrops(){
+    	return [];
+    }
+
+}

--- a/src/milk/entitymanager/entity/Monster.php
+++ b/src/milk/entitymanager/entity/Monster.php
@@ -11,6 +11,7 @@ use pocketmine\math\Math;
 use pocketmine\math\Vector3;
 use pocketmine\Player;
 use pocketmine\Server;
+use pocketmine\entity\Creature;
 
 abstract class Monster extends WalkEntity{
 
@@ -95,15 +96,26 @@ abstract class Monster extends WalkEntity{
         --$this->moveTime;
         ++$this->attackDelay;
         $target = $this->updateMove();
-        if($target instanceof Entity){
-            $this->attackEntity($target);
-        }elseif($target instanceof Vector3){
-            if((($this->x - $target->x) ** 2 + ($this->z - $target->z) ** 2) <= 1) $this->moveTime = 0;
+        
+        if($this->isFriendly){
+        	if(! $target instanceof Player){
+        		if($target instanceof Entity){
+        			$this->attackEntity($target);
+        		}elseif($target instanceof Vector3){
+        			if((($this->x - $target->x) ** 2 + ($this->z - $target->z) ** 2) <= 1) $this->moveTime = 0;
+        		}
+        	}
+        }else{
+		    if($target instanceof Entity){
+		        $this->attackEntity($target);
+		    }elseif($target instanceof Vector3){
+		        if((($this->x - $target->x) ** 2 + ($this->z - $target->z) ** 2) <= 1) $this->moveTime = 0;
+		    }
         }
         if($this->entityTick++ >= 5){
-            $this->entityTick = 0;
-            $this->entityBaseTick(5);
-        }
+       		$this->entityTick = 0;
+      		$this->entityBaseTick(5);
+      	}
     }
 
     public function entityBaseTick($tickDiff = 1){
@@ -147,8 +159,10 @@ abstract class Monster extends WalkEntity{
         return $hasUpdate;
     }
 
-    public function targetOption(Player $player, $distance){
-        return $player->spawned && $player->isAlive() && !$player->closed && $player->isSurvival() && $distance <= 81;
+    public function targetOption(Creature $creature, $distance){
+    	if($creature instanceof Player)
+        	return $creature->spawned && $creature->isAlive() && !$creature->closed && $creature->isSurvival() && $distance <= 81;
+    	return $creature->isAlive() && !$creature->closed && $distance <= 81;
     }
 
 }

--- a/src/milk/entitymanager/entity/Mooshroom.php
+++ b/src/milk/entitymanager/entity/Mooshroom.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace milk\entitymanager\entity;
+
+use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\entity\Creature;
+
+class Mooshroom extends Animal{
+    const NETWORK_ID = 16;
+
+    public $width = 1.6;
+    public $height = 1.12;
+
+    public function getName(){
+        return "Mooshroom";
+    }
+
+    public function initEntity(){
+        $this->setMaxHealth(10);
+        if(isset($this->namedtag->Health)){
+            $this->setHealth((int) $this->namedtag["Health"]);
+        }else{
+            $this->setHealth($this->getMaxHealth());
+        }
+        parent::initEntity();
+        $this->created = true;
+    }
+
+    public function targetOption(Creature $creature, $distance){
+    	if($creature instanceof Player)
+        	return $creature->spawned && $creature->isAlive() && !$creature->closed && $creature->getInventory()->getItemInHand()->getId() == Item::WHEAT && $distance <= 49;
+        return false;
+    }
+
+    public function getDrops(){
+        $drops = [];
+        if($this->lastDamageCause instanceof EntityDamageByEntityEvent){
+              $drops[] = Item::get(Item::MUSHROOM_STEW, 0, 1);
+        }
+        return $drops;
+    }
+}

--- a/src/milk/entitymanager/entity/Ocelot.php
+++ b/src/milk/entitymanager/entity/Ocelot.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace milk\entitymanager\entity;
+
+use pocketmine\entity\Entity;
+use pocketmine\nbt\tag\IntTag;
+use pocketmine\Player;
+use pocketmine\event\entity\EntityDamageEvent;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\item\Item;
+use pocketmine\entity\Creature;
+
+class Ocelot extends Monster{
+    const NETWORK_ID = 22;
+
+    public $width = 0.72;
+    public $length = 0.6;
+    public $height = 0.9;
+
+    private $angry = 0;
+
+    protected $speed = 1.5;
+
+    public function initEntity(){
+        $this->fireProof = true;
+        $this->setMaxHealth(10);
+        if(isset($this->namedtag->Health)){
+            $this->setHealth((int) $this->namedtag["Health"]);
+        }else{
+            $this->setHealth($this->getMaxHealth());
+        }
+        if(isset($this->namedtag->Angry)){
+            $this->angry = (int) $this->namedtag["Angry"];
+        }
+        $this->setMinDamage([0, 2]);
+        $this->setMaxDamage([0, 2]);
+        parent::initEntity();
+        $this->created = true;
+    }
+
+    public function saveNBT(){
+        $this->namedtag->Angry = new IntTag("Angry", $this->angry);
+        parent::saveNBT();
+    }
+
+    public function getName(){
+        return "Ocelot";
+    }
+
+    public function isAngry(){
+        return $this->angry > 0;
+    }
+
+    public function setAngry($val){
+        $this->angry = (int) $val;
+    }
+
+    public function targetOption(Creature $creature, $distance){
+    	if($creature instanceof Player)
+    		return ($creature->spawned && $creature->isAlive() && !$creature->closed && $creature->getInventory()->getItemInHand()->getId() == Item::RAW_FISH && $distance <= 49) or $this->isAngry();
+    	return parent::targetOption($creature, $distance);
+    }
+
+    public function attackEntity(Entity $player){
+        if($this->attackDelay > 10 && $this->distanceSquared($player) < 1.44){
+            $this->attackDelay = 0;
+            $ev = new EntityDamageByEntityEvent($this, $player, EntityDamageEvent::CAUSE_ENTITY_ATTACK, $this->getDamage());
+            $player->attack($ev->getFinalDamage(), $ev);
+        }
+    }
+
+    public function getDrops(){
+    	return [];
+    }
+
+}

--- a/src/milk/entitymanager/entity/Pig.php
+++ b/src/milk/entitymanager/entity/Pig.php
@@ -6,6 +6,7 @@ use pocketmine\entity\Rideable;
 use pocketmine\item\Item;
 use pocketmine\Player;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\entity\Creature;
 
 class Pig extends Animal implements Rideable{
     const NETWORK_ID = 12;
@@ -29,8 +30,10 @@ class Pig extends Animal implements Rideable{
         $this->created = true;
     }
 
-    public function targetOption(Player $player, $distance){
-        return $player->spawned && $player->isAlive() && !$player->closed && $player->getInventory()->getItemInHand()->getId() == Item::CARROT && $distance <= 49;
+    public function targetOption(Creature $creature, $distance){
+    	if($creature instanceof Player)
+        	return $creature->spawned && $creature->isAlive() && !$creature->closed && $creature->getInventory()->getItemInHand()->getId() == Item::CARROT && $distance <= 49;
+    	return false;
     }
 
     public function getDrops(){

--- a/src/milk/entitymanager/entity/PigZombie.php
+++ b/src/milk/entitymanager/entity/PigZombie.php
@@ -4,10 +4,10 @@ namespace milk\entitymanager\entity;
 
 use pocketmine\entity\Entity;
 use pocketmine\nbt\tag\IntTag;
-use pocketmine\Player;
 use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\item\Item;
+use pocketmine\entity\Creature;
 
 class PigZombie extends Monster{
     const NETWORK_ID = 36;
@@ -55,8 +55,8 @@ class PigZombie extends Monster{
         $this->angry = (int) $val;
     }
 
-    public function targetOption(Player $player, $distance){
-        return parent::targetOption($player, $distance) && $this->isAngry();
+    public function targetOption(Creature $creature, $distance){
+        return parent::targetOption($creature, $distance) && $this->isAngry();
     }
 
     public function attackEntity(Entity $player){

--- a/src/milk/entitymanager/entity/Rabbit.php
+++ b/src/milk/entitymanager/entity/Rabbit.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace milk\entitymanager\entity;
+
+use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\entity\Creature;
+
+class Rabbit extends Animal{
+    const NETWORK_ID = 18;
+
+    public $width = 0.4;
+    public $height = 0.75;
+
+    protected $speed = 1.2;
+    
+    public function getName(){
+        return "Rabbit";
+    }
+
+    public function initEntity(){
+        $this->setMaxHealth(4);
+        if(isset($this->namedtag->Health)){
+            $this->setHealth((int) $this->namedtag["Health"]);
+        }else{
+            $this->setHealth($this->getMaxHealth());
+        }
+        parent::initEntity();
+        $this->created = true;
+    }
+
+    public function targetOption(Creature $creature, $distance){
+    	if($creature instanceof Player)
+        	return $creature->spawned && $creature->isAlive() && !$creature->closed && $creature->getInventory()->getItemInHand()->getId() == Item::SEEDS && $distance <= 49;
+        return false;
+    }
+
+    public function getDrops(){
+    	return [];
+    }
+
+}

--- a/src/milk/entitymanager/entity/Sheep.php
+++ b/src/milk/entitymanager/entity/Sheep.php
@@ -6,6 +6,7 @@ use pocketmine\entity\Colorable;
 use pocketmine\item\Item;
 use pocketmine\Player;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\entity\Creature;
 
 class Sheep extends Animal implements Colorable{
     const NETWORK_ID = 13;
@@ -29,8 +30,10 @@ class Sheep extends Animal implements Colorable{
         $this->created = true;
     }
 
-    public function targetOption(Player $player, $distance){
-        return $player->spawned && $player->isAlive() && !$player->closed && $player->getInventory()->getItemInHand()->getId() == Item::SEEDS && $distance <= 49;
+    public function targetOption(Creature $creature, $distance){
+    	if($creature instanceof Player)
+        	return $creature->spawned && $creature->isAlive() && !$creature->closed && $creature->getInventory()->getItemInHand()->getId() == Item::SEEDS && $distance <= 49;
+        return false;
     }
 
     public function getDrops(){

--- a/src/milk/entitymanager/entity/Silverfish.php
+++ b/src/milk/entitymanager/entity/Silverfish.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace milk\entitymanager\entity;
+
+use pocketmine\entity\Entity;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\event\entity\EntityDamageEvent;
+
+class Silverfish extends Monster{
+    const NETWORK_ID = 39;
+
+    public $width = 0.7;
+    public $height = 0.7;
+
+    protected $speed = 1.4;
+
+    public function initEntity(){
+        if(isset($this->namedtag->Health)){
+            $this->setHealth((int) $this->namedtag["Health"]);
+        }else{
+            $this->setHealth(8);
+        }
+        $this->setMinDamage(1);
+        $this->setMaxDamage(1);
+        parent::initEntity();
+        $this->created = true;
+    }
+
+    public function getName(){
+        return "Silverfish";
+    }
+
+    public function attackEntity(Entity $player){
+        if($this->attackDelay > 10 && $this->distanceSquared($player) < 1){
+            $this->attackDelay = 0;
+            $ev = new EntityDamageByEntityEvent($this, $player, EntityDamageEvent::CAUSE_ENTITY_ATTACK, $this->getDamage());
+            $player->attack($ev->getFinalDamage(), $ev);
+        }
+    }
+
+    public function getDrops(){
+    	return [];
+    }
+
+}

--- a/src/milk/entitymanager/entity/Skeleton.php
+++ b/src/milk/entitymanager/entity/Skeleton.php
@@ -14,7 +14,6 @@ use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\DoubleTag;
 use pocketmine\nbt\tag\ListTag;
 use pocketmine\nbt\tag\FloatTag;
-use pocketmine\Player;
 
 class Skeleton extends Monster implements ProjectileSource{
     const NETWORK_ID = 34;
@@ -37,7 +36,7 @@ class Skeleton extends Monster implements ProjectileSource{
     }
 
     public function attackEntity(Entity $player){
-        if($player instanceof Player && $this->attackDelay > 30 && mt_rand(1, 32) < 4 && $this->distanceSquared($player) <= 55){
+        if($this->attackDelay > 30 && mt_rand(1, 32) < 4 && $this->distanceSquared($player) <= 55){
             $this->attackDelay = 0;
         
             $f = 1.2;
@@ -45,9 +44,9 @@ class Skeleton extends Monster implements ProjectileSource{
             $pitch = $this->pitch + mt_rand(-120, 120) / 10;
             $nbt = new CompoundTag("", [
                 "Pos" => new ListTag("Pos", [
-                    new DoubleTag("", $this->x),
+                    new DoubleTag("", $this->x + (-sin($yaw / 180 * M_PI) * cos($pitch / 180 * M_PI) * 0.5)),
                     new DoubleTag("", $this->y + 1.62),
-                    new DoubleTag("", $this->z)
+                    new DoubleTag("", $this->z +(cos($yaw / 180 * M_PI) * cos($pitch / 180 * M_PI) * 0.5))
                 ]),
                 "Motion" => new ListTag("Motion", [
                     new DoubleTag("", -sin($yaw / 180 * M_PI) * cos($pitch / 180 * M_PI) * $f),

--- a/src/milk/entitymanager/entity/Slime.php
+++ b/src/milk/entitymanager/entity/Slime.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace milk\entitymanager\entity;
+
+use pocketmine\item\Item;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\entity\Creature;
+
+class Slime extends Animal{
+    const NETWORK_ID = 37;
+
+    public $width = 1.2;
+    public $height = 1.2;
+    
+    protected $speed = 0.8;
+
+    public function getName(){
+        return "Slime";
+    }
+
+    public function initEntity(){
+        $this->setMaxHealth(4);
+        if(isset($this->namedtag->Health)){
+            $this->setHealth((int) $this->namedtag["Health"]);
+        }else{
+            $this->setHealth($this->getMaxHealth());
+        }
+        parent::initEntity();
+        $this->created = true;
+    }
+
+    public function targetOption(Creature $creature, $distance){
+    	return false;
+    }
+    
+    public function getDrops(){
+        $drops = [];
+        if($this->lastDamageCause instanceof EntityDamageByEntityEvent){
+        	$drops[] = Item::get(Item::SLIMEBALL, 0, mt_rand(0, 2));
+        }
+        return $drops;
+    }
+
+}

--- a/src/milk/entitymanager/entity/SnowGolem.php
+++ b/src/milk/entitymanager/entity/SnowGolem.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace milk\entitymanager\entity;
+
+use pocketmine\entity\Entity;
+use pocketmine\entity\Projectile;
+use pocketmine\entity\ProjectileSource;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\event\entity\EntityShootBowEvent;
+use pocketmine\event\entity\ProjectileLaunchEvent;
+use pocketmine\item\Item;
+use pocketmine\level\sound\LaunchSound;
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\DoubleTag;
+use pocketmine\nbt\tag\ListTag;
+use pocketmine\nbt\tag\FloatTag;
+use pocketmine\Player;
+use pocketmine\entity\Creature;
+
+class SnowGolem extends Monster implements ProjectileSource{
+    const NETWORK_ID = 21;
+
+    public $width = 0.65;
+    public $height = 1.2;
+
+    public function initEntity(){
+        if(isset($this->namedtag->Health)){
+            $this->setHealth((int) $this->namedtag["Health"]);
+        }else{
+            $this->setHealth($this->getMaxHealth());
+        }
+        parent::initEntity();
+        $this->setFriendly(true);
+        $this->created = true;
+    }
+
+    public function getName(){
+        return "SnowGolem";
+    }
+
+    public function attackEntity(Entity $player){
+        if($this->attackDelay > 23  && mt_rand(1, 32) < 4 && $this->distanceSquared($player) <= 55){
+            $this->attackDelay = 0;
+        
+            $f = 1.2;
+            $yaw = $this->yaw + mt_rand(-220, 220) / 10;
+            $pitch = $this->pitch + mt_rand(-120, 120) / 10;
+            $nbt = new CompoundTag("", [
+                "Pos" => new ListTag("Pos", [
+                    new DoubleTag("", $this->x + (-sin($yaw / 180 * M_PI) * cos($pitch / 180 * M_PI) * 0.5)),
+                    new DoubleTag("", $this->y + 1),
+                    new DoubleTag("", $this->z +(cos($yaw / 180 * M_PI) * cos($pitch / 180 * M_PI) * 0.5))
+                ]),
+                "Motion" => new ListTag("Motion", [
+                    new DoubleTag("", -sin($yaw / 180 * M_PI) * cos($pitch / 180 * M_PI)),
+                    new DoubleTag("", -sin($pitch / 180 * M_PI)),
+                    new DoubleTag("", cos($yaw / 180 * M_PI) * cos($pitch / 180 * M_PI))
+                ]),
+                "Rotation" => new ListTag("Rotation", [
+                    new FloatTag("", $yaw),
+                    new FloatTag("", $pitch)
+                ]),
+            ]);
+
+            /** @var Projectile $arrow */
+            $snowball = Entity::createEntity("Snowball", $this->chunk, $nbt, $this);
+            $snowball->setMotion ( $snowball->getMotion ()->multiply ( $f ) );
+            
+            /* Snowball damage change */
+            $property = (new \ReflectionClass ( $snowball ))->getProperty ( "damage" );
+            $property->setAccessible(true);
+            $property->setValue ( $snowball, 2 );
+            
+            $ev = new EntityShootBowEvent($this, Item::get(Item::ARROW, 0, 1), $snowball, $f);
+
+            $this->server->getPluginManager()->callEvent($ev);
+
+            $projectile = $ev->getProjectile();
+            if($ev->isCancelled()){
+                $projectile->kill();
+            }elseif($projectile instanceof Projectile){
+                $this->server->getPluginManager()->callEvent($launch = new ProjectileLaunchEvent($projectile));
+                if($launch->isCancelled()){
+                    $projectile->kill();
+                }else{
+                    $projectile->spawnToAll();
+                    $this->level->addSound(new LaunchSound($this), $this->getViewers());
+                }
+            }
+        }
+    }
+
+    public function getDrops(){
+        if($this->lastDamageCause instanceof EntityDamageByEntityEvent){
+            return [
+                Item::get(Item::SNOWBALL, 0, 15)
+            ];
+        }
+        return [];
+    }
+    
+    public function targetOption(Creature $creature, $distance){
+    	if(! $creature instanceof Player)
+    		return $creature->isAlive() && $distance <= 60;
+    	return false;
+    }
+}

--- a/src/milk/entitymanager/entity/Wolf.php
+++ b/src/milk/entitymanager/entity/Wolf.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace milk\entitymanager\entity;
+
+use pocketmine\entity\Entity;
+use pocketmine\nbt\tag\IntTag;
+use pocketmine\event\entity\EntityDamageEvent;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\entity\Creature;
+
+class Wolf extends Monster{
+    const NETWORK_ID = 14;
+
+    public $width = 0.72;
+    public $length = 0.6;
+    public $height = 0.9;
+
+    private $angry = 0;
+
+    protected $speed = 1.2;
+
+    public function initEntity(){
+        $this->fireProof = true;
+        $this->setMaxHealth(8);
+        if(isset($this->namedtag->Health)){
+            $this->setHealth((int) $this->namedtag["Health"]);
+        }else{
+            $this->setHealth($this->getMaxHealth());
+        }
+        if(isset($this->namedtag->Angry)){
+            $this->angry = (int) $this->namedtag["Angry"];
+        }
+        $this->setMinDamage([0, 3, 4, 6]);
+        $this->setMaxDamage([0, 3, 4, 6]);
+        parent::initEntity();
+        $this->created = true;
+    }
+
+    public function saveNBT(){
+        $this->namedtag->Angry = new IntTag("Angry", $this->angry);
+        parent::saveNBT();
+    }
+
+    public function getName(){
+        return "Wolf";
+    }
+
+    public function isAngry(){
+        return $this->angry > 0;
+    }
+
+    public function setAngry($val){
+        $this->angry = (int) $val;
+    }
+
+    public function targetOption(Creature $creature, $distance){
+    	return parent::targetOption($creature, $distance) and $this->isAngry();
+    }
+
+    public function attackEntity(Entity $player){
+        if($this->attackDelay > 10 && $this->distanceSquared($player) < 1.6){
+            $this->attackDelay = 0;
+            $ev = new EntityDamageByEntityEvent($this, $player, EntityDamageEvent::CAUSE_ENTITY_ATTACK, $this->getDamage());
+            $player->attack($ev->getFinalDamage(), $ev);
+        }
+    }
+
+    public function getDrops(){
+    	return [];
+    }
+
+}

--- a/src/milk/entitymanager/entity/Zombie.php
+++ b/src/milk/entitymanager/entity/Zombie.php
@@ -32,7 +32,7 @@ class Zombie extends Monster{
     }
 
     public function attackEntity(Entity $player){
-        if($this->attackDelay > 10 && $this->distanceSquared($player) < 1){
+        if($this->attackDelay > 10 && $this->distanceSquared($player) < 2){
             $this->attackDelay = 0;
             $ev = new EntityDamageByEntityEvent($this, $player, EntityDamageEvent::CAUSE_ENTITY_ATTACK, $this->getDamage());
             $player->attack($ev->getFinalDamage(), $ev);

--- a/src/milk/entitymanager/entity/ZombieVillager.php
+++ b/src/milk/entitymanager/entity/ZombieVillager.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace milk\entitymanager\entity;
+
+use pocketmine\entity\Entity;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\event\entity\EntityDamageEvent;
+use pocketmine\item\Item;
+
+class ZombieVillager extends Monster{
+    const NETWORK_ID = 44;
+
+    public $width = 0.72;
+    public $height = 1.8;
+
+    protected $speed = 1.1;
+
+    public function initEntity(){
+        if(isset($this->namedtag->Health)){
+            $this->setHealth((int) $this->namedtag["Health"]);
+        }else{
+            $this->setHealth($this->getMaxHealth());
+        }
+        $this->setMinDamage([0, 3, 4, 6]);
+        $this->setMaxDamage([0, 3, 4, 6]);
+        parent::initEntity();
+        $this->created = true;
+    }
+
+    public function getName(){
+        return "ZombieVillager";
+    }
+
+    public function attackEntity(Entity $player){
+        if($this->attackDelay > 10 && $this->distanceSquared($player) < 1){
+            $this->attackDelay = 0;
+            $ev = new EntityDamageByEntityEvent($this, $player, EntityDamageEvent::CAUSE_ENTITY_ATTACK, $this->getDamage());
+            $player->attack($ev->getFinalDamage(), $ev);
+        }
+    }
+
+    public function getDrops(){
+        $drops = [];
+        if($this->lastDamageCause instanceof EntityDamageByEntityEvent){
+            switch(mt_rand(0, 2)){
+                case 0:
+                    $drops[] = Item::get(Item::FEATHER, 0, 1);
+                    break;
+                case 1:
+                    $drops[] = Item::get(Item::CARROT, 0, 1);
+                    break;
+                case 2:
+                    $drops[] = Item::get(Item::POTATO, 0, 1);
+                    break;
+            }
+        }
+        return $drops;
+    }
+
+}

--- a/src/milk/entitymanager/task/SpawnEntityTask.php
+++ b/src/milk/entitymanager/task/SpawnEntityTask.php
@@ -31,12 +31,13 @@ class SpawnEntityTask extends PluginTask{
             if(mt_rand(...$rand) > $rand[0]) continue;
             $radius = (int) $owner->getData("autospawn.radius");
             $pos = $player->getPosition();
-            $pos->y = $player->level->getHighestBlockAt($pos->x += mt_rand(-$radius, $radius), $pos->z += mt_rand(-$radius, $radius));
+            $pos->y = $player->level->getHighestBlockAt($pos->x += mt_rand(-$radius, $radius), $pos->z += mt_rand(-$radius, $radius))+2;
+            
             $ent = [
-                ["Cow", "Pig", "Sheep", "Chicken", null, null],
-                ["Zombie", "Creeper", "Skeleton", "Spider", "PigZombie", "Enderman"]
+                ["Cow", "Pig", "Sheep", "Chicken", "Slime", "Wolf", "Ocelot", "Mooshroom", "Rabbit", "IronGolem", "SnowGolem"],
+                ["Zombie", "Creeper", "Skeleton", "Spider", "PigZombie", "Enderman", "CaveSpider", "MagmaCube", "ZombieVillager", "Ghast", "Blaze"]
             ];
-            EntityManager::createEntity($ent[mt_rand(0, 1)][mt_rand(0, 5)], $pos);
+            EntityManager::createEntity($ent[mt_rand(0, 1)][mt_rand(0, 10)], $pos);
         }
     }
 


### PR DESCRIPTION
유저가 몬스터를 공격하면 길게 넉백 되는 문제를 해결했고,
몇가지 몬스터들을 추가하였습니다.

추가로 작업한 특이점은, FlyEntity를 조금 더 구현해봤고,
철골렘 눈골렘 두 몬스터들을 개발하기 위해서

BaseEntity 에서 isFriendly 를 통해 아군/적군 여부를
몬스터간에 판별하고 몬스터간에 싸움이 발생할 수 있도록 했습니다.

(오징어만 빼고 다 개발해보았습니다)
